### PR TITLE
send oppName in result

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The resulting binary can be found in the ``build`` subfolder.
 
 # Contributing
 
-Feel free to submit pull requests, suggest new ideas and discuss issues. Track-o-Bot is about simplicity and a streamlined experience. Only features which benefit all users will be considered. 
+Feel free to submit pull requests, suggest new ideas and discuss issues. Track-o-Bot is about simplicity and usability. Only features which benefit all users will be considered. 
 
 # License
 

--- a/src/Core.cpp
+++ b/src/Core.cpp
@@ -8,6 +8,7 @@ Core::Core()
     mOrder( ORDER_UNKNOWN ),
     mOwnClass( CLASS_UNKNOWN ),
     mOpponentClass( CLASS_UNKNOWN ),
+    mOppName ( "" ),
     mDuration( 0 ),
     mGameClientRestartRequired( false )
 {
@@ -21,6 +22,7 @@ Core::Core()
   connect( &mLogTracker, SIGNAL( HandleOwnClass(Class) ), this, SLOT( HandleOwnClass(Class) ) ) ;
   connect( &mLogTracker, SIGNAL( HandleOpponentClass(Class) ), this, SLOT( HandleOpponentClass(Class) ) );
   connect( &mLogTracker, SIGNAL( HandleGameMode(GameMode) ), this, SLOT( HandleGameMode(GameMode) ) );
+  connect( &mLogTracker, SIGNAL( HandleOppName(QString) ), this, SLOT( HandleOppName(QString) ) );
 
   connect( &mLogTracker, SIGNAL( HandleMatchStart() ), this, SLOT( HandleMatchStart() ) );
   connect( &mLogTracker, SIGNAL( HandleMatchEnd(const ::CardHistoryList&) ), this, SLOT( HandleMatchEnd(const ::CardHistoryList&) ) );
@@ -98,6 +100,11 @@ void Core::HandleGameMode( GameMode mode ) {
   mGameMode = mode;
 }
 
+void Core::HandleOppName( QString oppName ) {
+  DEBUG( "HandleOppName %s", oppName.toStdString().c_str() );
+  mOppName = oppName;
+}
+
 void Core::UploadResult() {
   DEBUG( "UploadResult" );
 
@@ -106,6 +113,7 @@ void Core::UploadResult() {
       mOrder,
       mOwnClass,
       mOpponentClass,
+      mOppName,
       mLogTracker.CardHistoryList(),
       mDuration );
 

--- a/src/Core.h
+++ b/src/Core.h
@@ -22,6 +22,7 @@ private:
   GoingOrder            mOrder;
   Class                 mOwnClass;
   Class                 mOpponentClass;
+  QString               mOppName;
   int                   mDuration;
   CardHistoryList       mCardHistoryList;
 
@@ -42,6 +43,7 @@ private slots:
   void HandleOpponentClass( Class opponentClass );
   void HandleOrder( GoingOrder order );
   void HandleGameMode( GameMode mode );
+  void HandleOppName (QString oppName );
 
   void Tick();
 

--- a/src/HearthstoneLogTracker.cpp
+++ b/src/HearthstoneLogTracker.cpp
@@ -38,11 +38,56 @@ void HearthstoneLogTracker::Reset() {
   mTurnCounter = 0;
   mHeroPowerUsed = false;
   mCardHistoryList.clear();
+  mOppName = "HaveFun";
+  mPlayerName = "mharris717";
+}
+
+// void HearthstoneLogTracker::LookForOppName (const QString& line ) {
+//   QRegExp regex( "ProcessChanges.*name=([a-zA-Z0-9]+)].* entity=([a-zA-Z0-9]+) ");
+//   if( regex.indexIn(line) != -1 ) {
+//     QStringList captures = regex.capturedTexts();
+//     QString name = captures[1];
+//     QString entity = captures[2];
+
+//     if (name == entity && name != mOppName) {
+//       DEBUG( "Found Opp Name %s",name.toStdString().c_str() );
+//       mOppName = name;
+//     }
+
+//     if (name != entity) {
+//       DEBUG( "Opp Name Mismatch %s / %s",name.toStdString().c_str(),entity.toStdString().c_str() );
+//     }
+//   }
+// }
+
+void HearthstoneLogTracker::LookForOppName ( const QString& line ) {
+  QRegExp regex( "ProcessChanges.*name=([a-zA-Z0-9]+)\\].*\\sentity=([a-zA-Z0-9]+)\\s");
+  // QString line = "[Zone] ZoneChangeList.ProcessChanges() - processing index=11 change=powerTask=[power=[type=TAG_CHANGE entity=[id=2 cardId= name=Kajiura] tag=NUM_TURNS_LEFT value=1] complete=False] entity=Kajiura srcZoneTag=INVALID srcPos= dstZoneTag=INVALID dstPos=";
+  
+  if( regex.indexIn(line) != -1 ) {
+    QStringList captures = regex.capturedTexts();
+    QString name = captures[1];
+    QString entity = captures[2];
+
+    if (name != entity) {
+      DEBUG( "OPPNAME Mismatch %s / %s",name.toStdString().c_str(),entity.toStdString().c_str() );
+    }
+    else if (name == mPlayerName || name == "GameEntity") {
+      // DEBUG( "OPPNAME Found reserved name %s",name.toStdString().c_str() );
+    }
+    else if (name != mOppName) {
+      DEBUG( "OPPNAME Setting %s",name.toStdString().c_str() );
+      mOppName = name;
+      emit HandleOppName( name );
+    }
+  }
 }
 
 void HearthstoneLogTracker::HandleLogLine( const QString& line ) {
   if( line.trimmed().isEmpty() )
     return;
+
+  LookForOppName(line);
 
   // CardPlayed / CardReturned / PlayerDied
   QRegExp regex( "ProcessChanges.*cardId=(\\w+).*zone from (.*) -> (.*)" );

--- a/src/HearthstoneLogTracker.h
+++ b/src/HearthstoneLogTracker.h
@@ -12,6 +12,8 @@ private:
   int mTurnCounter;
   bool mHeroPowerUsed;
   int mHeroPlayerId;
+  QString mOppName;
+  QString mPlayerName;
 
   CardHistoryList mCardHistoryList;
 
@@ -24,6 +26,7 @@ private:
 
 private slots:
   void HandleLogLine( const QString& line );
+  void LookForOppName( const QString& line );
 
 signals:
   void HandleMatchStart();
@@ -34,6 +37,7 @@ signals:
   void HandleGameMode( GameMode mode );
   void HandleOpponentClass( Class opponentClass );
   void HandleOwnClass( Class ownClass );
+  void HandleOppName( QString oppName );
 
 public:
   HearthstoneLogTracker();

--- a/src/Tracker.cpp
+++ b/src/Tracker.cpp
@@ -37,7 +37,7 @@ void Tracker::EnsureAccountIsSetUp() {
   }
 }
 
-void Tracker::AddResult( GameMode mode, Outcome outcome, GoingOrder order, Class ownClass, Class opponentClass, const CardHistoryList& historyCardList, int durationInSeconds )
+void Tracker::AddResult( GameMode mode, Outcome outcome, GoingOrder order, Class ownClass, Class opponentClass, QString oppName, const CardHistoryList& historyCardList, int durationInSeconds )
 {
   if( mode == MODE_SOLO_ADVENTURES ) {
     LOG( "Ignore solo adventure." );
@@ -99,6 +99,7 @@ void Tracker::AddResult( GameMode mode, Outcome outcome, GoingOrder order, Class
   result[ "win" ]      = ( outcome == OUTCOME_VICTORY );
   result[ "mode" ]     = MODE_NAMES[ mode ];
   result[ "duration" ] = durationInSeconds;
+  result[ "oppName" ] = oppName;
 
   QtJson::JsonArray card_history;
   for( CardHistoryList::const_iterator it = historyCardList.begin(); it != historyCardList.end(); ++it ) {

--- a/src/Tracker.h
+++ b/src/Tracker.h
@@ -36,7 +36,7 @@ private slots:
 public:
   bool IsAccountSetUp() const;
 
-  void AddResult( GameMode mode, Outcome outcome, GoingOrder order, Class ownClass, Class opponentClass, const CardHistoryList& cardHistoryList, int durationInSeconds );
+  void AddResult( GameMode mode, Outcome outcome, GoingOrder order, Class ownClass, Class opponentClass, QString oppName, const CardHistoryList& cardHistoryList, int durationInSeconds );
   void CreateAndStoreAccount();
   void OpenProfile();
   void EnsureAccountIsSetUp();


### PR DESCRIPTION
Not suggesting you merge this, I'm sure there is a ton wrong with it, I barely know C++ anymore. 

I'd like to be able to log the opponent's name, and see their name in the game display on the website.

I can't speak to what happens after the JSON hits your server, but up to that point this does seem to work.

The matching regex is terrible, should be better, and gamertag's can probably have other characters in them. 

I have two reasons for wanting to log opponent's name:
- Helpful to find people you played previously, etc
- Could enable use of Track-o-Bot as an automatic reporting tool for tournaments.
