### PR TITLE
fallback to default path on mac if no entry found in agent.db

### DIFF
--- a/src/Hearthstone.cpp
+++ b/src/Hearthstone.cpp
@@ -192,6 +192,13 @@ QString Hearthstone::LogPath( const QString& fileName ) const {
   }
 #endif
 
+#ifdef Q_OS_MAC
+  if( hsPath.isEmpty() ) {
+    LOG( "Using default path for path" );
+    hsPath = QString("/Applications/Hearthstone");
+  }
+#endif
+
   if( hsPath.isEmpty() ) {
     ERR( "Hearthstone path not found" );
     return QString();


### PR DESCRIPTION
New installs of hearthstone do not populate the agent.db, it seems. Fall back to a default path if a path can't be found in the agent.db file.