### PR TITLE
Fixes issue #146 for windows platform

### DIFF
--- a/src/Hearthstone.cpp
+++ b/src/Hearthstone.cpp
@@ -16,7 +16,7 @@
 #include "Shlobj.h"
 #endif
 
-DEFINE_SINGLETON_SCOPE( Hearthstone )
+DEFINE_SINGLETON_SCOPE( Hearthstone );
 
 Hearthstone::Hearthstone()
  : mCapture( NULL ), mGameRunning( false )
@@ -48,6 +48,7 @@ void Hearthstone::Update() {
   bool isRunning = mCapture->WindowFound();
 
   if( isRunning ) {
+    emit FocusChanged( mCapture->Focus() );
     static int lastLeft = 0, lastTop = 0, lastWidth = 0, lastHeight = 0;
     if( lastLeft != mCapture->Left() || lastTop != mCapture->Top() ||
         lastWidth != mCapture->Width() || lastHeight != mCapture->Height() )

--- a/src/Hearthstone.h
+++ b/src/Hearthstone.h
@@ -18,7 +18,7 @@ class Hearthstone : public QObject
 {
   Q_OBJECT
 
-  DEFINE_SINGLETON( Hearthstone )
+  DEFINE_SINGLETON( Hearthstone );
 
 private:
   WindowCapture *mCapture;
@@ -52,6 +52,7 @@ signals:
   void GameStopped();
   void GameRequiresRestart();
   void GameWindowChanged( int x, int y, int w, int h );
+  void FocusChanged( bool value );
 
 private slots:
   void Update();

--- a/src/WinWindowCapture.cpp
+++ b/src/WinWindowCapture.cpp
@@ -4,7 +4,6 @@
 #include <QtWinExtras/qwinfunctions.h>
 #include <psapi.h>
 
-
 WinWindowCapture::WinWindowCapture()
   : mHwnd( NULL )
 {
@@ -16,6 +15,7 @@ HWND WinWindowCapture::FindHWND() {
   }
 
   HWND hwnd = FindWindowW( NULL, L"Hearthstone" );
+
   if( !hwnd ) {
     // Fallback for localized
     HWND unityHwnd = FindWindowW( L"UnityWndClass", NULL );
@@ -97,5 +97,14 @@ QPixmap WinWindowCapture::Capture( int x, int y, int w, int h ) {
   }
 
   return pixmap;
+}
+
+bool WinWindowCapture::Focus() {
+
+    HWND activeWindow = GetForegroundWindow();
+    if( activeWindow == FindHWND() )
+        return true;
+    else
+        return false;
 }
 

--- a/src/WinWindowCapture.h
+++ b/src/WinWindowCapture.h
@@ -27,5 +27,7 @@ public:
   int Top();
 
   QPixmap Capture( int x, int y, int w, int h );
+
+  bool Focus();
 };
 

--- a/src/WindowCapture.h
+++ b/src/WindowCapture.h
@@ -16,5 +16,7 @@ public:
   virtual int Top() = 0;
 
   virtual QPixmap Capture( int x, int y, int w, int h ) = 0;
+
+  virtual bool Focus() = 0;
 };
 

--- a/src/ui/Overlay.cpp
+++ b/src/ui/Overlay.cpp
@@ -174,6 +174,7 @@ Overlay::Overlay( QWidget *parent )
   connect( Hearthstone::Instance(), &Hearthstone::GameWindowChanged, this, &Overlay::HandleGameWindowChanged );
   connect( Hearthstone::Instance(), &Hearthstone::GameStarted, this, &Overlay::HandleGameStarted );
   connect( Hearthstone::Instance(), &Hearthstone::GameStopped, this, &Overlay::HandleGameStopped );
+  connect( Hearthstone::Instance(), &Hearthstone::FocusChanged, this, &Overlay::HandleFocusChanged );
 
   connect( &mCheckForHoverTimer, &QTimer::timeout, this, &Overlay::CheckForHover );
 
@@ -362,4 +363,8 @@ void Overlay::HandleOverlaySettingChanged( bool enabled ) {
   UNUSED_ARG( enabled );
 
   Update();
+}
+
+void Overlay::HandleFocusChanged( bool focus ) {
+  focus && Settings::Instance()->OverlayEnabled() ? show() : hide();
 }

--- a/src/ui/Overlay.h
+++ b/src/ui/Overlay.h
@@ -56,6 +56,7 @@ public slots:
   void HandleCardsDrawnUpdate( const ::CardHistoryList& cardsDrawn );
 
   void HandleOverlaySettingChanged( bool enabled );
+  void HandleFocusChanged( bool enabled );
 
 };
 


### PR DESCRIPTION
Based on fix for identical bug in linux port. Should work without any problems ( had some problems with testing this on linux ). On osx build will fail with this if OSXWindowCapture::Focus() isnt implemented

Same thing was reported at redit https://www.reddit.com/r/trackobot/comments/4jgu72/hover_overlay_bug/