### PR TITLE
Build instructions for windows and overlay on small displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Build Dependencies
 
 * Qt 5.7
+* Ruby (any stable version)
 * (OS X) Sparkle
 * (Windows) WinSparkle
 
@@ -16,19 +17,32 @@ brew link qt5 --force
 
 ## Windows
 
+* Install [Ruby](https://rubyinstaller.org/downloads/)
 * Install [Qt](http://qt-project.org/downloads) 
- * I use the Qt libraries for Windows VS 2013.
+ * I use the Qt libraries for Windows VS 2013. Make sure to choose 32 bit under Windows.
 * Install [WinSparkle](https://github.com/vslavik/winsparkle) 
- * Clone the repository and build the library, for example with VS 2013. The precompiled releases are ancient.
+ * Clone the repository and build the library, for example with VS 2013. The precompiled releases are ancient. Make sure to build 32 bit.
 
 # Build Instructions
+
+## Mac OS X
 
 ```
 qmake
 make
 ```
 
-(Use ``nmake`` instead of ``make`` on Windows)
+## Windows
+
+* Add Qt, VS 2013 and WinSparkle to your system path.
+* Initialize the environment variables:
+ * call qtenv2.bat (default location: ..\Qt\5.5\msvc2013\bin\qtenv2.bat)
+ * call vcvarsall.bat (default location: ..\VS2013\VC\vcvarsall.bat)
+
+```
+qmake
+nmake
+```
 
 The resulting binary can be found in the ``build`` subfolder.
 

--- a/src/ui/Overlay.cpp
+++ b/src/ui/Overlay.cpp
@@ -85,16 +85,16 @@ private:
 
   void DrawCardLine( QPainter& painter, int x, int y, int width, int height, const QString& name, int count ) const {
     painter.save();
-    painter.drawText( x, y, width, height, Qt::AlignLeft | Qt::AlignVCenter | Qt::TextDontClip, name );
+	QString text = name;
 
-    if( count > 1 ) {
-      int nameWidth = QFontMetrics( painter.font() ).width( name + " " );
-      QString countString = QString( "x%1" ).arg( count );
+	if( count > 1 ) {
+      text.prepend(QString( "%1x " ).arg( count ));
       QFont font = painter.font();
       font.setBold( true );
       painter.setFont( font );
-      painter.drawText( x + nameWidth, y, width - nameWidth, height, Qt::AlignLeft | Qt::AlignVCenter | Qt::TextDontClip, countString );
     }
+
+    painter.drawText( x, y, width, height, Qt::AlignLeft | Qt::AlignVCenter | Qt::TextDontClip, text );
     painter.restore();
   }
 
@@ -235,7 +235,7 @@ void Overlay::paintEvent( QPaintEvent* ) {
     history = &mPlayerHistory;
     rect = mPlayerDeckRect;
   } else if( mShowPlayerHistory == PLAYER_OPPONENT && mOpponentHistory.count() > 0 ) {
-    title = "Cards played by opponent";
+    title = "Opponent played";
     history = &mOpponentHistory;
     rect = mOpponentDeckRect;
   }


### PR DESCRIPTION
The contribution of this pull request is two-fold:

1. I improved the documentation of build instructions and dependencies for Windows, to make it a bit easier for others to start with track-o-bot. It would be nice to double check what can be adapted for Mac OS. (second commit)
2. I have a rather small display that has issues with the overlay if the card name exceeds a certain length. This is especially annoying when you have no clue if a card was played once or twice. See the screenshot:
![trackobotoverlay2](https://cloud.githubusercontent.com/assets/25305424/24397075/844059ae-13a5-11e7-94d4-21a9dbddf67d.jpg)
To overcome this, I simply placed the "2x" in front of the card name:
![trackobotoverlay-new2](https://cloud.githubusercontent.com/assets/25305424/24397097/8c78aa40-13a5-11e7-8e4e-f5f02cba61b0.jpg)
I considered changing the text size to make everything fit on the screen, however, the text is already quite small and we are talking about small displays. I think it is better to cut off the rest of the card name. Experienced players will have no effort to extrapolate something like "Murloc Warlead" to "Murloc Warleader".

Let me know what you think!
Cheers,
Tommy