### PR TITLE
Detect build when Hearthstone is launched

### DIFF
--- a/src/Hearthstone.cpp
+++ b/src/Hearthstone.cpp
@@ -24,7 +24,7 @@
 DEFINE_SINGLETON_SCOPE( Hearthstone );
 
 Hearthstone::Hearthstone()
- : mCapture( NULL ), mGameRunning( false ), mGameHasFocus( false )
+ : mCapture( NULL ), mGameRunning( false ), mGameHasFocus( false ), mBuild( 0 )
 {
 #ifdef Q_OS_MAC
   mCapture = new OSXWindowCapture();
@@ -37,6 +37,7 @@ Hearthstone::Hearthstone()
   // So just check only once in a while
   mTimer = new QTimer( this );
   connect( mTimer, &QTimer::timeout, this, &Hearthstone::Update );
+  connect( this, &Hearthstone::GameStarted, this, &Hearthstone::DetectBuild );
 #ifdef Q_OS_MAC
   mTimer->start( 5000 );
 #else
@@ -322,6 +323,10 @@ QString Hearthstone::DetectRegion() const {
   return region;
 }
 
+int Hearthstone::Build() const {
+  return mBuild;
+}
+
 #ifdef Q_OS_WIN
 // http://stackoverflow.com/questions/940707/how-do-i-programatically-get-the-version-of-a-dll-or-exe-file
 int Win32ExtractBuildFromPE( const wchar_t *szVersionFile ) {
@@ -355,8 +360,7 @@ int Win32ExtractBuildFromPE( const wchar_t *szVersionFile ) {
 }
 #endif
 
-int Hearthstone::DetectBuild() const {
-  int build = 0;
+void Hearthstone::DetectBuild() {
   QString hsPath = Settings::Instance()->HearthstoneDirectoryPath();
   QString buildPath;
 
@@ -367,14 +371,13 @@ int Hearthstone::DetectBuild() const {
     QString version = settings.value( "BlizzardFileVersion", "1.0.0.0" ).toString();
 
     if( !version.isEmpty() ) {
-      build = version.split(".").last().toInt();
+      mBuild = version.split(".").last().toInt();
     }
 #elif defined Q_OS_WIN
     buildPath = QString( "%1/Hearthstone.exe" ).arg( hsPath );
-      build = Win32ExtractBuildFromPE( buildPath.toStdWString().c_str() );
+      mBuild = Win32ExtractBuildFromPE( buildPath.toStdWString().c_str() );
 #endif
   }
-  return build;
 }
 
 QString Hearthstone::DetectLocale() const {

--- a/src/Hearthstone.h
+++ b/src/Hearthstone.h
@@ -26,9 +26,10 @@ private:
   bool mRestartRequired; // in case HS needs to be restarted for log changes to take effect
   bool mGameRunning;
   bool mGameHasFocus;
+  int mBuild;
 
   QString ReadAgentAttribute( const char *attributeName ) const;
-
+  void DetectBuild();
   QTimer *mTimer;
 
 public:
@@ -45,7 +46,7 @@ public:
   QString LogConfigPath() const;
   QString DetectHearthstonePath() const;
   QString DetectRegion() const;
-  int DetectBuild() const;
+  int Build() const;
   QString DetectLocale() const;
 
   int Width() const;

--- a/src/HearthstoneCardDB.cpp
+++ b/src/HearthstoneCardDB.cpp
@@ -33,14 +33,14 @@ QString HearthstoneCardDB::Type( const QString& id ) const {
 }
 
 QString HearthstoneCardDB::CardsJsonLocalPath() {
-  int build = Hearthstone::Instance()->DetectBuild();
+  int build = Hearthstone::Instance()->Build();
   QString locale = Hearthstone::Instance()->DetectLocale();
   QString appDataLocation = QStandardPaths::standardLocations( QStandardPaths::AppDataLocation ).first();
   return QString( "%1/cards_%2_%3.json" ).arg( appDataLocation ).arg( build ).arg( locale );
 }
 
 QString HearthstoneCardDB::CardsJsonRemoteUrl() {
-  int build = Hearthstone::Instance()->DetectBuild();
+  int build = Hearthstone::Instance()->Build();
   QString locale = Hearthstone::Instance()->DetectLocale();
   return QString( "%1/%2/%3/cards.json" ).arg( HEARTHSTONE_JSON_API_URL ).arg( build ).arg( locale );
 }
@@ -51,7 +51,7 @@ bool HearthstoneCardDB::Load() {
 
   Unload();
 
-  int build = Hearthstone::Instance()->DetectBuild();
+  int build = Hearthstone::Instance()->Build();
   if( !build ) {
     ERR( "Could not determine build during card db load" );
     return false;


### PR DESCRIPTION
Hi,
We only need to detect build on hearthstone start ( since it won't change until restart )
DetecBuid() is invoked multiple of times and via HearthstoneCardDB::CardsJsonLocalPath() ( among others) - on mac it opens a file and reads it; if it the same on windows as its done in wine there are also multiple allocations to get file version.