### PR TITLE
correctly determine ranked games again

### DIFF
--- a/src/HearthstoneLogTracker.cpp
+++ b/src/HearthstoneLogTracker.cpp
@@ -66,7 +66,7 @@ HearthstoneLogTracker::HearthstoneLogTracker( QObject *parent )
   RegisterHearthstoneLogLineHandler( "Power", "GameState.DebugPrintEntityChoices()", "type=INVALID zone=DECK zonePos=0 player=(?<id>\\d+)", &HearthstoneLogTracker::OnPlayerId );
   RegisterHearthstoneLogLineHandler( "Power", "GameState.DebugPrintEntityChoices()", "Entities\\[\\d+\\]=\\[.*player=(?<id>\\d+).*\\]", &HearthstoneLogTracker::OnPlayerId );
   RegisterHearthstoneLogLineHandler( "Bob", "", "legend rank (?<rank>\\w+)", &HearthstoneLogTracker::OnLegendRank );
-  RegisterHearthstoneLogLineHandler( "Asset", "", "name=rank_window", &HearthstoneLogTracker::OnRanked );
+  RegisterHearthstoneLogLineHandler( "Asset", "", "assetPath=rank_window", &HearthstoneLogTracker::OnRanked );
   RegisterHearthstoneLogLineHandler( "Power", "", "Start Spectator Game", &HearthstoneLogTracker::OnStartSpectating );
   RegisterHearthstoneLogLineHandler( "Power", "", "End Spectator Mode", &HearthstoneLogTracker::OnStopSpectating ); // MODE!
 }


### PR DESCRIPTION
Since the _Knights of the Frozen Throne_ Expansion, Track-O-Bot does not recognize ranked games anymore and saves them as casual games. That's because of a change in Hearthstones logfiles.

The bug is relatively easy fixed, just by adjusting a regex.

Proof screenshot that it works again:

<img width="754" alt="bildschirmfoto 2017-12-14 um 18 56 05" src="https://user-images.githubusercontent.com/5645703/34006977-832be6b8-e100-11e7-9149-c459c0af0095.png">

This should close #222.